### PR TITLE
[PR] Disable Shortcode UI when WooCommerce is enabled

### DIFF
--- a/includes/class-wsuwp-extended-woocommerce.php
+++ b/includes/class-wsuwp-extended-woocommerce.php
@@ -31,8 +31,19 @@ class WSUWP_Extended_WooCommerce {
 		if ( ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
-
+		add_filter( 'wsuwp_embeds_enable_facebook_post', '__return_false' );
+		add_action( 'init', array( $this, 'remove_shortcode_ui' ), 3 );
 		add_action( 'init', array( $this, 'remove_switch_blog_action' ) );
+	}
+
+	/**
+	 * Effectively disables the Shortcode UI problem due to a conflict in the Select2
+	 * version used by that plugin and WooCommerce.
+	 *
+	 * @since 0.0.2
+	 */
+	public function remove_shortcode_ui() {
+		remove_action( 'init', 'shortcode_ui_init', 5 );
 	}
 
 	/**


### PR DESCRIPTION
WooCommerce relies on an older version of Select2. Shortcode UI
uses a newer version which has breaking changes. Until this conflict
is resolved, we'll need to disable Shortcode UI on sites that are
using WooCommerce

Relies on the changes in
https://github.com/washingtonstateuniversity/WSUWP-Plugin-Embeds/pull/50