### PR TITLE
[PR] Disable Image Shortcake when WooCommerce is active

### DIFF
--- a/includes/class-wsuwp-extended-woocommerce.php
+++ b/includes/class-wsuwp-extended-woocommerce.php
@@ -44,6 +44,7 @@ class WSUWP_Extended_WooCommerce {
 	 */
 	public function remove_shortcode_ui() {
 		remove_action( 'init', 'shortcode_ui_init', 5 );
+		remove_action( 'init', 'Image_Shortcake::get_instance' );
 	}
 
 	/**


### PR DESCRIPTION
Image Shortcake will instantiate Shortcode UI if Shortcode UI has not already instantiated itself.